### PR TITLE
Feature/refactor template info

### DIFF
--- a/website/mock/template.ts
+++ b/website/mock/template.ts
@@ -1,6 +1,6 @@
 import { Response} from 'express';
-import { TemplateMetaData } from '../src/pages/Workspace/utils/types/TemplateTypes'
-import { WorkspaceInfoMetaData } from '@/pages/Workspace/utils/types/WorkspaceTypes';
+import { TemplateMetaData } from '../src/utils/types/TemplateTypes'
+import { WorkspaceInfoMetaData } from '@/utils/types/WorkspaceTypes';
 import moment from 'moment';
 
 const template: TemplateMetaData = {
@@ -27,9 +27,7 @@ const worksapce: WorkspaceInfoMetaData = {
   template: template
 } 
 export default {
-  'GET /api/templates/:id': (req: Request, res: Response) => {
-    res.send(template);
-  },
+
   'GET /api/workspaces/:id': (req: Request, res: Response) => {
     res.send(worksapce);
   },

--- a/website/package.json
+++ b/website/package.json
@@ -63,7 +63,8 @@
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
     "react-markdown": "^8.0.7",
-    "styled-components": "^6.0.7"
+    "styled-components": "^6.0.7",
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
     "@ant-design/pro-cli": "^3.1.0",

--- a/website/src/pages/NewWorkspace/index.tsx
+++ b/website/src/pages/NewWorkspace/index.tsx
@@ -1,4 +1,4 @@
-import { getAccessibleTemplates } from '@/services/quantumlab/template';
+import TemplateApi from '@/services/quantumlab/template';
 import { useModel } from '@umijs/max';
 import {
   Button,
@@ -52,7 +52,7 @@ const NewWorkspace = () => {
 
   useEffect(() => {
     // function to fetch templates
-    getAccessibleTemplates()
+    TemplateApi.getAccessibleTemplates()
     .then((res)=>{
       setLoadingTemplates(false)
       setTemplates(res)

--- a/website/src/pages/NewWorkspace/index.tsx
+++ b/website/src/pages/NewWorkspace/index.tsx
@@ -201,7 +201,7 @@ const NewWorkspace = () => {
 
         <Form.Item name="template_id" label="Templates">
           <Select
-            value={currentTemplate ? currentTemplate.id: undefined}
+            defaultValue={selectedTemplate?.id || undefined}
             placeholder="Select a template"
             onChange={onTemplateChange}
             loading={!templates} // Show loading indicator if templates are not available

--- a/website/src/pages/NewWorkspace/index.tsx
+++ b/website/src/pages/NewWorkspace/index.tsx
@@ -22,7 +22,7 @@ const { Option } = Select;
 
 const NewWorkspace = () => {
   const [form] = Form.useForm();
-  const [selectedTemplate, setSelectedTemplate] = useState<TemplateClass | null>(null);
+  const [selectedTemplate, setSelectedTemplate] = useState<TemplateClass | undefined>(undefined);
   const [templates, setTemplates] = useState<TemplateClass[]>([]);
   const [loadingTemplates, setLoadingTemplates] = useState(true);
   const [templatesFetchFailed, setTemplatesFetchFailed] = useState(false);
@@ -32,14 +32,14 @@ const NewWorkspace = () => {
   useEffect(() => {
     // function to fetch templates
     TemplateApi.getAccessibleTemplates()
-    .then((res)=>{
-      setLoadingTemplates(false)
-      setTemplates(res)
-    })
-    .catch((error)=>{
-      setTemplatesFetchFailed(true)
-      throw new Error(error.message || 'Error fetching templates.');
-    })
+      .then((res)=>{
+        setLoadingTemplates(false)
+        setTemplates(res)
+      })
+      .catch((error)=>{
+        setTemplatesFetchFailed(true)
+        throw new Error(error.message || 'Error fetching templates.');
+      })
   }, []);
 
   useEffect(()=> {
@@ -68,11 +68,7 @@ const NewWorkspace = () => {
 
   const onTemplateChange = (selectedTemplateId: number) => {
     const template = templates.find((template) => template.id === selectedTemplateId);
-    if (template && typeof template.parameters === 'string') {
-      // Parse the Parameters from string to object
-      const paramsObject = JSON.parse(template.parameters);
-      setSelectedTemplate({ ...template, parameters: paramsObject });
-    }
+    setSelectedTemplate(template)
   };
 
   const onFinish = async (values: any) => {
@@ -85,7 +81,6 @@ const NewWorkspace = () => {
         },
         {},
       );
-      console.log('parameters:', parameters);
       
       // Adjust data to fit the new format
       const adjustedValues = {
@@ -109,7 +104,7 @@ const NewWorkspace = () => {
         },
       };
 
-      console.log('adjustedValues:', adjustedValues);
+    console.log('adjustedValues:', adjustedValues);
 
       const response = await fetch('/api/workspaces', {
         method: 'POST',
@@ -206,7 +201,7 @@ const NewWorkspace = () => {
 
         <Form.Item name="template_id" label="Templates">
           <Select
-            defaultValue={currentTemplate ? currentTemplate.id: undefined}
+            value={currentTemplate ? currentTemplate.id: undefined}
             placeholder="Select a template"
             onChange={onTemplateChange}
             loading={!templates} // Show loading indicator if templates are not available

--- a/website/src/pages/TemplateInfo/index.tsx
+++ b/website/src/pages/TemplateInfo/index.tsx
@@ -8,15 +8,17 @@ import {
   Typography,
 } from 'antd';
 import { ArrowLeftOutlined, PlusOutlined } from '@ant-design/icons';
-import { history } from '@umijs/max';
+import { history, useParams } from '@umijs/max';
 import { useEmotionCss } from '@ant-design/use-emotion-css';
 import { FrownOutlined } from '@ant-design/icons';
 import ReactMarkdown from 'react-markdown';
 import useTemplateStore from '@/stores/TemplateStore'
+import { useEffect } from 'react';
 
 const TemplateInfo: React.FC = () => {
   const { Title, Text } = Typography;
-  const { currentTemplate, setCurrentTemplate } = useTemplateStore()
+  const { templateId } = useParams()
+  const { fetchedTemplates, currentTemplate, setCurrentTemplate } = useTemplateStore()
   
   const projectNameClass = useEmotionCss(() => {
     return {
@@ -137,10 +139,13 @@ const TemplateInfo: React.FC = () => {
     );
   };
 
+  useEffect(() => {
+    const template = fetchedTemplates.filter((t) => t.id===Number(templateId))
+    setCurrentTemplate(template[0])
+  },[])
   
   const handleBack = () => {
     history.push('/workspace', { tag: 'template' });
-    setCurrentTemplate(undefined)
   };
 
   const handleCreateWorkspace = (templateId: number) => {

--- a/website/src/pages/TemplateInfo/index.tsx
+++ b/website/src/pages/TemplateInfo/index.tsx
@@ -2,47 +2,21 @@ import {
   Button,
   Divider, 
   Image,
-  message,
   Row, 
   Result,
   Space,
   Typography,
 } from 'antd';
 import { ArrowLeftOutlined, PlusOutlined } from '@ant-design/icons';
-import { history, useIntl, useParams } from '@umijs/max';
+import { history } from '@umijs/max';
 import { useEmotionCss } from '@ant-design/use-emotion-css';
-import { useEffect, useState } from 'react';
-import { TemplateClass } from "@/utils/types/TemplateTypes";
 import { FrownOutlined } from '@ant-design/icons';
-import TemplateApi from "@/services/quantumlab/template";
 import ReactMarkdown from 'react-markdown';
-import { PageLoading } from '@ant-design/pro-components';
+import useTemplateStore from '@/stores/TemplateStore'
 
 const TemplateInfo: React.FC = () => {
   const { Title, Text } = Typography;
-  const { templateId } = useParams()
-  const [template, setTemplate] = useState<TemplateClass|undefined>(undefined)
-  const [loading, setLoading] = useState(true);
-  const intl = useIntl();
-
-  useEffect(() => {
-    TemplateApi.getTemplate(templateId as string)
-      .then((res) => {
-        if (!res.message){
-          setTemplate(res)
-        } else {
-          const Errormessage = intl.formatMessage({
-            id: 'pages.templateInfo.failure',
-            defaultMessage: res.message,
-          });
-          message.error(Errormessage);
-        }
-        setLoading(false);
-      })
-      .catch((error) => {
-        console.log(error)
-      });
-  }, []);
+  const { currentTemplate, setCurrentTemplate } = useTemplateStore()
   
   const projectNameClass = useEmotionCss(() => {
     return {
@@ -166,17 +140,15 @@ const TemplateInfo: React.FC = () => {
   
   const handleBack = () => {
     history.push('/workspace', { tag: 'template' });
+    setCurrentTemplate(undefined)
   };
 
   const handleCreateWorkspace = (templateId: number) => {
     history.push('/workspace/new', { templateId: templateId });
   }
 
-  if(loading){
-    return <PageLoading/>
-  }
   return (
-    <>{template ? (
+    <>{currentTemplate ? (
       <>
         <div>
         <Button 
@@ -196,13 +168,14 @@ const TemplateInfo: React.FC = () => {
         <Image
           width={96}
           height={96}
-          src={template.icon}
+          src={currentTemplate.icon}
         />
         <div style={{ width: '100%' }}>
-          <Title className={projectNameClass}>{template?.filename}</Title>
+          <Title className={projectNameClass}>{currentTemplate?.filename}</Title>
           <Button 
+            data-test-id='new-workspace-template'
             icon={<PlusOutlined />}
-            onClick={() => handleCreateWorkspace(template.id)}
+            onClick={() => handleCreateWorkspace(currentTemplate.id)}
             className={createBtnClass}>
             New Workspace Using This Template
           </Button>
@@ -216,7 +189,7 @@ const TemplateInfo: React.FC = () => {
           Overview
         </Title>
         <Space size="middle">
-          {Object.entries(template?.parameters || {}).map(([key, param]) =>
+          {Object.entries(currentTemplate?.parameters || {}).map(([key, param]) =>
             renderParam(key, param.label, param.selections)
           )}
         </Space>
@@ -229,7 +202,7 @@ const TemplateInfo: React.FC = () => {
           README
         </Title>
         <div className={readmeClass}>
-          <ReactMarkdown>{template.readme}</ReactMarkdown>
+          <ReactMarkdown>{currentTemplate.readme}</ReactMarkdown>
         </div>
       </div>
     </>) : (

--- a/website/src/pages/Workspace/components/ProjectsTable.tsx
+++ b/website/src/pages/Workspace/components/ProjectsTable.tsx
@@ -12,6 +12,42 @@ import {Image} from 'antd'
 interface Props {
   data: number | undefined
 }
+const periods = {
+  year: 12*30 * 24 * 60 * 60 * 1000,
+  month: 30 * 24 * 60 * 60 * 1000,
+  week: 7 * 24 * 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+  hour: 60 * 60 * 1000,
+  minute: 60 * 1000
+};
+const durationCalculator = (t : string)=>{
+  
+  let lastAcc : Date = new Date(t);
+  let curtime : Date = new Date();
+  let diff = curtime.valueOf()-lastAcc.valueOf()
+  if(diff>periods.year){
+    const m = Math.floor(diff / periods.year)
+    return m===1?'a year ago': String(m) + " years ago";
+  }else if (diff > periods.month) {
+    const m = Math.floor(diff / periods.month)
+    return m===1?'a month ago': String(m) + " months ago";
+  } else if (diff > periods.week) {
+    const w = Math.floor(diff / periods.week)
+    return w===1? 'a week ago': String(w)+ " weeks ago";
+  } else if (diff > periods.day) {
+    const d = Math.floor(diff / periods.day)
+    return d===1? 'a day ago' : String(d)+" days ago";
+  } else if (diff > periods.hour) {
+    const h = Math.floor(diff / periods.hour)
+    return h===1? 'an hour ago': String(h)+" hours ago";
+  } else if (diff > periods.minute) {
+    const m = Math.floor(diff / periods.minute)
+    return m===1? 'a minute ago': String(m)+" minutes ago";
+  }
+  return "Just now";
+
+}
+
 const columns: ColumnsType<WorkspaceInfoMetaData> = [
   {
     title: '',
@@ -122,39 +158,5 @@ const ProjectsTable = (props: Props) => {
     rowKey={workspaces => String(workspaces.id)} />;
 
 }
-var periods = {
-  year: 12*30 * 24 * 60 * 60 * 1000,
-  month: 30 * 24 * 60 * 60 * 1000,
-  week: 7 * 24 * 60 * 60 * 1000,
-  day: 24 * 60 * 60 * 1000,
-  hour: 60 * 60 * 1000,
-  minute: 60 * 1000
-};
-const durationCalculator = (t : string)=>{
-  
-  let lastAcc : Date = new Date(t);
-  let curtime : Date = new Date();
-  let diff = curtime.valueOf()-lastAcc.valueOf()
-  if(diff>periods.year){
-    const m = Math.floor(diff / periods.year)
-    return m===1?'a year ago': String(m) + " years ago";
-  }else if (diff > periods.month) {
-    const m = Math.floor(diff / periods.month)
-    return m===1?'a month ago': String(m) + " months ago";
-  } else if (diff > periods.week) {
-    const w = Math.floor(diff / periods.week)
-    return w===1? 'a week ago': String(w)+ " weeks ago";
-  } else if (diff > periods.day) {
-    const d = Math.floor(diff / periods.day)
-    return d===1? 'a day ago' : String(d)+" days ago";
-  } else if (diff > periods.hour) {
-    const h = Math.floor(diff / periods.hour)
-    return h===1? 'an hour ago': String(h)+" hours ago";
-  } else if (diff > periods.minute) {
-    const m = Math.floor(diff / periods.minute)
-    return m===1? 'a minute ago': String(m)+" minutes ago";
-  }
-  return "Just now";
 
-}
 export default ProjectsTable

--- a/website/src/pages/Workspace/components/TemplateTable.tsx
+++ b/website/src/pages/Workspace/components/TemplateTable.tsx
@@ -1,68 +1,72 @@
 import { ColumnsType } from 'antd/es/table'
 import React, { useEffect, useState } from 'react'
-import { Space, Table, Image } from 'antd'
-import { Link } from '@umijs/max'
+import { Button, Space, Table, Image } from 'antd'
+import { history } from '@umijs/max'
 import { DoubleRightOutlined } from '@ant-design/icons'
-import { getAccessibleTemplates } from '@/services/quantumlab/template'
+import TemplateApi from '@/services/quantumlab/template'
 import { PageLoading } from '@ant-design/pro-components'
-import { TemplateMetaData } from '../utils/types/TemplateTypes.tsx'
+import { TemplateClass } from '@/utils/types/TemplateTypes'
+import useTemplateStore from '@/stores/TemplateStore'
 
-interface Props {
-  data: number | undefined
-}
-
-const columns: ColumnsType<TemplateMetaData> = [
-  {
-    title: '',
-    key: 'templateId',
-    dataIndex: 'icon',
-    render: (icon) => {
-
-      return (<>
-        <Image src={icon} />
-      </>)
-    }
-  },
-  {
-    title: 'Name',
-    dataIndex: 'filename',
-    key: 'filename',
-    render: (text) => <a style={{ fontSize: '15px', fontWeight: 'bold', color: 'black' }}>{text}</a>
-  },
-  {
-    title: 'Date Created',
-    dataIndex: 'createdAt',
-    key: 'createdAt',
-    render: (t) => {
-      return <a style={{ fontSize: '15px', color: 'black' }}>{t ? new Date(t).toLocaleString().substring(0, 9) : new Date().toLocaleString().substring(0, 9)}</a>
-    }
-  },
-  {
-    title: 'Access Level',
-    dataIndex: 'accessLevel',
-    key: 'accessLevel',
-
-  },
-  {
-    title: ' ',
-    key: 'action',
-    dataIndex: 'id',
-    render: (id) => (
-      <Space size="middle">
-        <Link to={'/template/' + `${id}`}>
-          <DoubleRightOutlined />
-        </Link>
-      </Space>
-    ),
-  },
-]
-
-const TemplateTable = (props: Props) => {
-  const [templates, setTemplates] = useState([])
+const TemplateTable = () => {
+  const [templates, setTemplates] = useState<TemplateClass[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const { setCurrentTemplate } = useTemplateStore()
+  const handleTemplateinfo = (id: number) => {
+    const template = templates.filter((t) => t.id===id)
+    setCurrentTemplate(template[0])
+    history.push('/template/' + id);
+  }
+  const columns: ColumnsType<TemplateClass> = [
+    {
+      title: '',
+      key: 'templateId',
+      dataIndex: 'icon',
+      render: (icon) => {
+  
+        return (<>
+          <Image src={icon} />
+        </>)
+      }
+    },
+    {
+      title: 'Name',
+      dataIndex: 'filename',
+      key: 'filename',
+      render: (text) => <a style={{ fontSize: '15px', fontWeight: 'bold', color: 'black' }}>{text}</a>
+    },
+    {
+      title: 'Date Created',
+      dataIndex: 'createdAt',
+      key: 'createdAt',
+      render: (t) => {
+        return <a style={{ fontSize: '15px', color: 'black' }}>{t ? new Date(t).toLocaleString().substring(0, 9) : new Date().toLocaleString().substring(0, 9)}</a>
+      }
+    },
+    {
+      title: 'Access Level',
+      dataIndex: 'accessLevel',
+      key: 'accessLevel',
+  
+    },
+    {
+      title: ' ',
+      key: 'action',
+      dataIndex: 'id',
+      render: (id) => (
+        <Space size="middle">
+          <Button 
+            type='link'
+            icon={<DoubleRightOutlined />} 
+            onClick={() => handleTemplateinfo(id)}
+          />
+        </Space>
+      ),
+    },
+  ]
   useEffect(() => {
-    getAccessibleTemplates()
+    TemplateApi.getAccessibleTemplates()
       .then((res) => {
         setTemplates(res);
         setLoading(false);

--- a/website/src/pages/Workspace/components/TemplateTable.tsx
+++ b/website/src/pages/Workspace/components/TemplateTable.tsx
@@ -9,13 +9,10 @@ import { TemplateClass } from '@/utils/types/TemplateTypes'
 import useTemplateStore from '@/stores/TemplateStore'
 
 const TemplateTable = () => {
-  const [templates, setTemplates] = useState<TemplateClass[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
-  const { setCurrentTemplate } = useTemplateStore()
+  const { fetchedTemplates, setFetchedTemplates } = useTemplateStore()
   const handleTemplateinfo = (id: number) => {
-    const template = templates.filter((t) => t.id===id)
-    setCurrentTemplate(template[0])
     history.push('/template/' + id);
   }
   const columns: ColumnsType<TemplateClass> = [
@@ -68,7 +65,7 @@ const TemplateTable = () => {
   useEffect(() => {
     TemplateApi.getAccessibleTemplates()
       .then((res) => {
-        setTemplates(res);
+        setFetchedTemplates(res)
         setLoading(false);
       })
       .catch((error) => {
@@ -81,7 +78,7 @@ const TemplateTable = () => {
   if (loading) {
     return <PageLoading />
   }
-  return <Table columns={columns} dataSource={templates}
+  return <Table columns={columns} dataSource={fetchedTemplates}
     rowKey={t => String(t.id)} />
 
 }

--- a/website/src/pages/Workspace/index.tsx
+++ b/website/src/pages/Workspace/index.tsx
@@ -4,6 +4,7 @@ import ProjectsTable from './components/ProjectsTable';
 import TemplateTable from './components/TemplateTable';
 import { history, useModel} from '@umijs/max';
 import { useLocation } from 'umi';
+import useTemplateStore from '@/stores/TemplateStore';
 
 const App: React.FC = () => {
   const [viewP, setViewP] = useState(true);
@@ -11,8 +12,10 @@ const App: React.FC = () => {
   const { initialState } = useModel('@@initialState');
   const location = useLocation();
   const { tag } = location.state || 'workspace';
+  const { setCurrentTemplate } = useTemplateStore()
 
   useEffect(()=> {
+    setCurrentTemplate(undefined)
     if(tag === 'template') {
       setViewP(false);
       setViewT(true);
@@ -78,7 +81,7 @@ const App: React.FC = () => {
         </Button>
       </div>
       {viewP && <ProjectsTable data={initialState?.currentUser?.id} />}
-      {viewT && <TemplateTable data={initialState?.currentUser?.id}/>}
+      {viewT && <TemplateTable />}
 
     </>
   );

--- a/website/src/services/quantumlab/template.ts
+++ b/website/src/services/quantumlab/template.ts
@@ -1,29 +1,25 @@
-import { request } from '@umijs/max';
 import { BaseApi } from '@/utils/BaseApi';
-import { TemplateClass } from '@/utils/types/TemplateTypes';
-
+import { TemplateClass, TemplateMetaData } from '@/utils/types/TemplateTypes';
+import { request } from '@umijs/max';
 class TemplateApi extends BaseApi {
-  getTemplate(id: string) {
-    return this.loadByGet('/api/templates/'+id)
-      .then((res) => {
-        return res.message ? res.message : TemplateClass.fromDTO(res)
-    })
-  }
 
+  getAccessibleTemplates() {
+    return this.loadByGet('/api/templates')
+      .then((res) => {
+        if(!res.message) {
+          let templates: TemplateClass[] = []
+          res.forEach((t: TemplateMetaData) => {
+            templates.push(TemplateClass.fromDTO(t))
+          })
+          return templates
+        }
+        return res.message
+      })
+  }
 
 }
 export default new TemplateApi()
-//get all templates
-export async function getAllTemplates(){
-    //console.log(id)
-    return request('/api/templates',{
-      method: 'GET',
-      headers:{
-        'Content-Type': 'application/json',
-        
-      }
-    })
-  }
+
   //get all templates that user allowed to access
 export async function getAccessibleTemplates(){
     //console.log(id)

--- a/website/src/stores/TemplateStore.ts
+++ b/website/src/stores/TemplateStore.ts
@@ -1,0 +1,15 @@
+import { TemplateClass } from "@/utils/types/TemplateTypes"
+import create from "zustand"
+export type TemplateStore = {
+  currentTemplate: TemplateClass
+  setCurrentTemplate: (template: TemplateClass | undefined) => void
+}
+
+const useTemplateStore = create<TemplateStore>((set) => ({
+  currentTemplate: new TemplateClass(0, [], '', 0, '', ''),
+  setCurrentTemplate: (template: TemplateClass | undefined) => {
+    set({currentTemplate: template})
+  }
+}))
+
+export default useTemplateStore

--- a/website/src/stores/TemplateStore.ts
+++ b/website/src/stores/TemplateStore.ts
@@ -1,12 +1,18 @@
 import { TemplateClass } from "@/utils/types/TemplateTypes"
 import create from "zustand"
 export type TemplateStore = {
-  currentTemplate: TemplateClass
+  fetchedTemplates: TemplateClass[]
+  currentTemplate: TemplateClass | undefined
+  setFetchedTemplates: (templates: TemplateClass[] | undefined) => void
   setCurrentTemplate: (template: TemplateClass | undefined) => void
 }
 
 const useTemplateStore = create<TemplateStore>((set) => ({
-  currentTemplate: new TemplateClass(0, [], '', 0, '', ''),
+  fetchedTemplates: [],
+  currentTemplate: undefined,
+  setFetchedTemplates: (templates: TemplateClass[] | undefined) => {
+    set({fetchedTemplates: templates})
+  },
   setCurrentTemplate: (template: TemplateClass | undefined) => {
     set({currentTemplate: template})
   }

--- a/website/tests/cypress/e2e/template_info.cy.js
+++ b/website/tests/cypress/e2e/template_info.cy.js
@@ -1,0 +1,38 @@
+describe('Template Info', () => {
+  beforeEach(() => {
+    cy.autoLogin('workspacequantum@gmail.com','workspacequantum@gmail.com')
+    cy.visit(`${Cypress.env('QUANTUMLAB_WEB')}/workspace`)
+    cy.get('.ant-tabs-tab-btn:contains("Templates")').click();
+    cy.get('.ant-btn-icon').click();
+  })
+
+  it('should display template information', () => {
+    //Template Info Page
+    cy.url().should('include', '/template');  
+  });
+
+
+  it('should go back to Templates tab when hit Back button', () => {
+    cy.get('button.ant-btn-text:contains("Back to Templates")').click();
+    cy.url().should('include', '/workspace'); 
+    // check if displaying Templates Tab by default
+    cy.get('.ant-tabs-tab-active:contains("Templates")').click();
+  });
+
+  it('should go to New Workspace when hit New Workspace button', () => {
+    cy.get('[data-test-id="new-workspace-template"').click();
+    cy.url().should('include', '/workspace/new'); 
+    // check if Template Params are fetched by default
+    // check selector type param
+    cy.get('label').should('contain', 'Available Zone')
+    cy.get('input[id$=availableZone]').click();
+    cy.get('input[id$=availableZone]')
+      .invoke('attr', 'aria-expanded')
+      .should('eq','true')
+    // check input type param
+    cy.get('label').should('contain', 'Disk Size')
+    cy.get('input[id$=diskSize]')
+      .should('not.have.attr', 'aria-expanded')
+  });
+
+})

--- a/website/tests/cypress/support/commands.js
+++ b/website/tests/cypress/support/commands.js
@@ -1,19 +1,7 @@
-Cypress.Commands.add('autoLogin', (uemail, upassword) => {
-    
-    cy.request({
-        method: 'POST',
-        url:`${Cypress.env(Cypress.env('mock')?'QUANTUMLAB_WEB':'API_LINK')}/api/auth/login`,
-        headers: {
-            'Content-Type': 'application/json',
-        },
-        body:{
-            email:uemail,
-            password:upassword
-        }
-    })
-    .its('body')
-    .then((body)=>{
-        window.localStorage.setItem('token',body.accessToken)
-        console.log(body)
-    })
-})
+Cypress.Commands.add('autoLogin', (email, password) => {
+    cy.visit(`${Cypress.env('QUANTUMLAB_WEB')}`)
+    cy.get('input#email').type(email);
+    cy.get('input#password').type(password);
+    cy.get('button').contains('Login').click()
+    cy.contains('Hello').should('be.visible');
+});


### PR DESCRIPTION
Refactor Template Info Page:
1. Remove getTemplate by id API as it doesn't exist
2. Implement TemplateStore to store the current selected template
3. Refactor TemplateApi class and replace some of the functions (e.g. getAccessibleTemplates)
4. Remove mock API for getTemplate by id 
5. Add e2e testing for Template Info Page